### PR TITLE
Add haproxy to the playground

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECTS=gerrit-master gerrit-slave gerrit-slave-nginx gerrit-slave-httpd
+PROJECTS=gerrit-master gerrit-master-nginx gerrit-slave gerrit-slave-nginx gerrit-slave-httpd gerrit-haproxy
 
 start: build
 	docker-compose up -d

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,8 @@ services:
     networks:
       - gerrit-net
 
-  gerrit-master:
-    image: gerrit-master
+  gerrit-master-nginx:
+    build: gerrit-master-nginx
     ports:
       - "18080:8080"
       - "29418:29418"
@@ -21,19 +21,30 @@ services:
       - postgres
 
   gerrit-slave-nginx:
-    image: gerrit-slave-nginx
+    build: gerrit-slave-nginx
     ports:
       - "18081:8080"
     networks:
       - gerrit-net
 
   gerrit-slave-httpd:
-    image: gerrit-slave-httpd
+    build: gerrit-slave-httpd
     ports:
       - "18082:8080"
     networks:
       - gerrit-net
 
+  gerrit-haproxy:
+    build: gerrit-haproxy
+    ports:
+      - "80:80"
+    networks:
+      - gerrit-net
+    depends_on:
+      - gerrit-master-nginx
+      - gerrit-slave-nginx
+      - gerrit-slave-httpd
+        
 networks:
   gerrit-net:
     driver: bridge

--- a/gerrit-haproxy/Dockerfile
+++ b/gerrit-haproxy/Dockerfile
@@ -1,0 +1,3 @@
+FROM haproxy:1.7
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+

--- a/gerrit-haproxy/haproxy.cfg
+++ b/gerrit-haproxy/haproxy.cfg
@@ -1,0 +1,39 @@
+global
+        maxconn 4096
+        log 127.0.0.1 local0 debug
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  log-health-checks
+        option  dontlognull
+        retries 3
+        option redispatch
+        option http-server-close
+        option forwardfor
+        maxconn 2000
+        timeout connect 5s
+        timeout client  15min
+        timeout server  15min
+        stats enable
+        stats refresh 5s
+        stats uri /haproxy?stats
+        stats realm Strictly\ Private
+        stats auth admin:secret
+
+frontend http
+  bind *:80
+  use_backend slaves if { path_reg ^/.*/git-upload-pack }
+  use_backend slaves if { query service=git-upload-pack }
+  default_backend masters
+
+backend masters
+   balance roundrobin
+   option forwardfor
+   server master1 gerrit-master-nginx:8888 check
+
+backend slaves
+   balance roundrobin
+   server slave1 gerrit-slave-nginx:8888 check
+   server slave2 gerrit-slave-httpd:8888 check

--- a/gerrit-master-nginx/Dockerfile
+++ b/gerrit-master-nginx/Dockerfile
@@ -1,0 +1,12 @@
+FROM gerrit-master
+
+# Install and Configure NGINX and other system tools
+RUN apt-get install -y fcgiwrap nginx && \
+    cp /usr/share/doc/fcgiwrap/examples/nginx.conf /etc/nginx/fcgiwrap.conf && \
+    sed -i 's/www-data/gerrit/g' /etc/init.d/fcgiwrap
+ADD nginx.conf /etc/nginx/
+ADD server-git.conf /etc/nginx/sites-enabled/
+
+ADD start.sh /bin/
+CMD /bin/start.sh
+

--- a/gerrit-master-nginx/nginx.conf
+++ b/gerrit-master-nginx/nginx.conf
@@ -1,0 +1,63 @@
+user gerrit;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+	worker_connections 1024;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	tcp_nodelay on;
+	keepalive_timeout 65;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+	error_log /var/log/nginx/error.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+	gzip_disable "msie6";
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}

--- a/gerrit-master-nginx/server-git.conf
+++ b/gerrit-master-nginx/server-git.conf
@@ -1,0 +1,10 @@
+server {
+	  listen 8888;
+	  server_name 127.0.0.1;
+
+	  location ^~ / {
+	    proxy_pass        http://127.0.0.1:8080;
+	    proxy_set_header  X-Forwarded-For $remote_addr;
+	    proxy_set_header  Host $host;
+	  }
+}

--- a/gerrit-master-nginx/start.sh
+++ b/gerrit-master-nginx/start.sh
@@ -2,6 +2,11 @@
 
 chown -R gerrit: /var/gerrit/.ssh
 chmod 600 /var/gerrit/.ssh/id_rsa
+chmod 600 /var/gerrit/.ssh/authorized_keys
+
+/etc/init.d/ssh start
+/etc/init.d/nginx start
+/etc/init.d/fcgiwrap start
 
 wait-for-it.sh gerrit-slave-nginx:22 -- echo "Slave is up"
 sudo -u gerrit ssh -oStrictHostKeyChecking=no gerrit-slave-nginx exit
@@ -10,7 +15,7 @@ sudo -u gerrit ssh -oStrictHostKeyChecking=no gerrit-slave-httpd exit
 
 wait-for-it.sh postgres:5432 -- echo "Postgres is up"
 sudo -u gerrit rm -Rf /var/gerrit/git/*
-sudo -u gerrit java -jar /var/gerrit/bin/gerrit.war init -d /var/gerrit --batch --install-plugin replication
+sudo -u gerrit java -jar /var/gerrit/bin/gerrit.war init -d /var/gerrit --batch --install-all-plugins
 
 /etc/init.d/gerrit start &
 touch /var/gerrit/logs/error_log /var/gerrit/logs/http_log /var/gerrit/logs/replication_log && chown -R gerrit: /var/gerrit && tail -f /var/gerrit/logs/*

--- a/gerrit-master/Dockerfile
+++ b/gerrit-master/Dockerfile
@@ -1,9 +1,9 @@
-FROM gerritforge/gerrit-ubuntu15.04:2.13.1
+FROM gerritforge/gerrit-ubuntu15.04:2.13.5
 
 USER root
 
 RUN apt-get install -y openjdk-8-jdk && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
-    apt-get install -y iputils-ping netcat
+    apt-get install -y iputils-ping netcat net-tools sudo openssh-server
 
 
 USER gerrit
@@ -15,13 +15,9 @@ ADD replication.config /var/gerrit/etc/
 RUN mkdir /var/gerrit/.ssh
 ADD id_rsa /var/gerrit/.ssh
 ADD id_rsa.pub /var/gerrit/.ssh
+ADD id_rsa.pub /var/gerrit/.ssh/authorized_keys
 ADD config /var/gerrit/.ssh
 
 USER root
 
-RUN apt-get install -y net-tools netcat inetutils-ping
-
-ADD start.sh /bin/
 ADD wait-for-it.sh /bin/
-
-CMD /bin/start.sh

--- a/gerrit-master/gerrit.config
+++ b/gerrit-master/gerrit.config
@@ -1,6 +1,6 @@
 [gerrit]
 	basePath = git
-	canonicalWebUrl = http://localhost:8080/
+	canonicalWebUrl = http://localhost/
 [database]
 	type = postgresql
 	hostname = postgres
@@ -13,9 +13,11 @@
 [sendemail]
 	smtpServer = localhost
 [sshd]
-	listenAddress = *:29418
+	listenAddress = 127.0.0.1:29418
+	requestLog = true
 [httpd]
-	listenUrl = http://*:8080/
+	listenUrl = proxy-http://127.0.0.1:8080/
+	requestLog = true
 [cache]
 	directory = cache
 [container]

--- a/gerrit-slave-httpd/start.sh
+++ b/gerrit-slave-httpd/start.sh
@@ -6,6 +6,6 @@ chmod 600 /var/gerrit/.ssh/authorized_keys
 /etc/init.d/ssh start
 /etc/init.d/apache2 start
 
-wait-for-it.sh -t 60 gerrit-master:8080 -- echo "Gerrit master is up"
+wait-for-it.sh -t 60 gerrit-master-nginx:8080 -- echo "Gerrit master is up"
 /etc/init.d/gerrit start &
 touch /var/gerrit/logs/error_log && chown -R gerrit: /var/gerrit && tail -f /var/gerrit/logs/error_log

--- a/gerrit-slave-nginx/start.sh
+++ b/gerrit-slave-nginx/start.sh
@@ -7,6 +7,6 @@ chmod 600 /var/gerrit/.ssh/authorized_keys
 /etc/init.d/nginx start
 /etc/init.d/fcgiwrap start
 
-wait-for-it.sh -t 60 gerrit-master:8080 -- echo "Gerrit master is up"
+wait-for-it.sh -t 60 gerrit-master-nginx:8080 -- echo "Gerrit master is up"
 /etc/init.d/gerrit start &
 touch  /var/gerrit/logs/error_log && chown -R gerrit: /var/gerrit && tail -f /var/gerrit/logs/error_log

--- a/gerrit-slave/Dockerfile
+++ b/gerrit-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM gerritforge/gerrit-ubuntu15.04:2.13.1
+FROM gerritforge/gerrit-ubuntu15.04:2.13.5
 
 USER root
 

--- a/gerrit-slave/gerrit.config
+++ b/gerrit-slave/gerrit.config
@@ -1,6 +1,6 @@
 [gerrit]
 	basePath = git
-	canonicalWebUrl = http://e386f1033735:8080/
+	canonicalWebUrl = http://localhost/
 [database]
         type = postgresql
         hostname = postgres
@@ -13,9 +13,11 @@
 [sendemail]
 	smtpServer = localhost
 [sshd]
-	listenAddress = *:29418
+	listenAddress = 127.0.0.1:29418
+	requestLog = true
 [httpd]
-	listenUrl = http://*:8080/
+	listenUrl = proxy-http://127.0.0.1:8080/
+	requestLog = true
 [cache]
 	directory = cache
 [container]


### PR DESCRIPTION
Setup the gerrit master to run behind a nginx reverse proxy.  Add a
haproxy to the playground to provide load balancing to the gerrit
master and slaves.  Setup haproxy to direct all git clone/fetch
operations to the slaves and direct all other operations to the
masters.